### PR TITLE
Fix README usage syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import { AccessControl, Role } from "@chronark/access";
 type Statements = {
   user: ["read", "write", "dance"];
   team: ["read", "write"];
-;
+};
 
 /**
  * Create an access control instance and pass the Statements type to enjoy full


### PR DESCRIPTION
### What's been changed
 - Updated README.md
	 - There was a missing curly bracket `}` causing both invalid syntax & broken syntax highlighting